### PR TITLE
Fix handling errors

### DIFF
--- a/src/sendgrid_clj/core.clj
+++ b/src/sendgrid_clj/core.clj
@@ -83,7 +83,7 @@
 (defmacro with-error-handling [& body]
   `(try ~@body
      (catch Exception e#
-       (prn (.message e#)))))
+       (prn (.getMessage e#)))))
 
 (defn <>
   "Performs a HTTP request to SendGrid API"

--- a/test/sendgrid_clj/core_test.clj
+++ b/test/sendgrid_clj/core_test.clj
@@ -37,6 +37,15 @@
                                   :subject "Mail"
                                   :text "<h1>Hello world</h1>"}))))))
 
+(deftest test-url-to-long-error
+  (testing "big send"
+    (is (= "success"
+           (:message (send-email (get-auth)
+                                 {:to (get-sg-to)
+                                  :from "test@test.com"
+                                  :subject "Mail"
+                                  :html (clojure.string/join (repeat 100000 "b"))}))))))
+
 (deftest test-stats
   (testing "stats"
     (let [output (stats (get-auth))]


### PR DESCRIPTION
And add a test that shows that send-email should use a post to avoid 414
